### PR TITLE
Revert "Revert "Adding Schema for Tool Outputs"" (#894)

### DIFF
--- a/codegen-examples/examples/swebench_agent_run/local_run.ipynb
+++ b/codegen-examples/examples/swebench_agent_run/local_run.ipynb
@@ -32,7 +32,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "await run_eval(use_existing_preds=None, dataset=\"lite\", length=20, repo=\"django/django\", num_workers=10, model=\"claude-3-7-sonnet-latest\")"
+    "await run_eval(use_existing_preds=None, dataset=\"lite\", length=5, repo=\"django/django\", num_workers=10, model=\"claude-3-7-sonnet-latest\")"
    ]
   },
   {

--- a/src/codegen/agents/data.py
+++ b/src/codegen/agents/data.py
@@ -52,6 +52,7 @@ class ToolMessageData(BaseMessage):
     tool_name: Optional[str] = None
     tool_response: Optional[str] = None
     tool_id: Optional[str] = None
+    status: Optional[str] = None
 
 
 @dataclass

--- a/src/codegen/agents/tracer.py
+++ b/src/codegen/agents/tracer.py
@@ -71,7 +71,14 @@ class MessageStreamTracer:
             tool_calls = [ToolCall(name=tc.get("name"), arguments=tc.get("arguments"), id=tc.get("id")) for tc in tool_calls_data]
             return AssistantMessage(type=message_type, content=content, tool_calls=tool_calls)
         elif message_type == "tool":
-            return ToolMessageData(type=message_type, content=content, tool_name=getattr(latest_message, "name", None), tool_response=content, tool_id=getattr(latest_message, "tool_call_id", None))
+            return ToolMessageData(
+                type=message_type,
+                content=content,
+                tool_name=getattr(latest_message, "name", None),
+                tool_response=getattr(latest_message, "artifact", content),
+                tool_id=getattr(latest_message, "tool_call_id", None),
+                status=getattr(latest_message, "status", None),
+            )
         elif message_type == "function":
             return FunctionMessageData(type=message_type, content=content)
         else:

--- a/src/codegen/extensions/langchain/graph.py
+++ b/src/codegen/extensions/langchain/graph.py
@@ -100,7 +100,7 @@ class AgentGraph:
             messages.append(HumanMessage(content=query))
 
         result = self.model.invoke([self.system_message, *messages])
-        if isinstance(result, AIMessage):
+        if isinstance(result, AIMessage) and not result.tool_calls:
             updated_messages = [*messages, result]
             return {"messages": updated_messages, "final_answer": result.content}
 
@@ -455,7 +455,7 @@ class AgentGraph:
                     return f"Error: Could not identify the tool you're trying to use.\n\nAvailable tools:\n{available_tools}\n\nPlease use one of the available tools with the correct parameters."
 
             # For other types of errors
-            return f"Error executing tool: {error_msg}\n\nPlease check your tool usage and try again with the correct parameters."
+            return f"Error executing tool: {exception!s}\n\nPlease check your tool usage and try again with the correct parameters."
 
         # Add nodes
         builder.add_node("reasoner", self.reasoner, retry=retry_policy)

--- a/src/codegen/extensions/tools/list_directory.py
+++ b/src/codegen/extensions/tools/list_directory.py
@@ -2,12 +2,13 @@
 
 from typing import ClassVar
 
+from langchain_core.messages import ToolMessage
 from pydantic import Field
 
+from codegen.extensions.tools.observation import Observation
+from codegen.extensions.tools.tool_output_types import ListDirectoryArtifacts
 from codegen.sdk.core.codebase import Codebase
 from codegen.sdk.core.directory import Directory
-
-from .observation import Observation
 
 
 class DirectoryInfo(Observation):
@@ -31,6 +32,14 @@ class DirectoryInfo(Observation):
         default=False,
         description="Whether this is a leaf node (at max depth)",
     )
+    depth: int = Field(
+        default=0,
+        description="Current depth in the tree",
+    )
+    max_depth: int = Field(
+        default=1,
+        description="Maximum depth allowed",
+    )
 
     str_template: ClassVar[str] = "Directory {path} ({file_count} files, {dir_count} subdirs)"
 
@@ -41,7 +50,7 @@ class DirectoryInfo(Observation):
             "dir_count": len(self.subdirectories),
         }
 
-    def render(self) -> str:
+    def render_as_string(self) -> str:
         """Render directory listing as a file tree."""
         lines = [
             f"[LIST DIRECTORY]: {self.path}",
@@ -97,6 +106,26 @@ class DirectoryInfo(Observation):
 
         return "\n".join(lines)
 
+    def to_artifacts(self) -> ListDirectoryArtifacts:
+        """Convert directory info to artifacts for UI."""
+        artifacts: ListDirectoryArtifacts = {
+            "dirpath": self.path,
+            "name": self.name,
+            "is_leaf": self.is_leaf,
+            "depth": self.depth,
+            "max_depth": self.max_depth,
+        }
+
+        if self.files is not None:
+            artifacts["files"] = self.files
+            artifacts["file_paths"] = [f"{self.path}/{f}" for f in self.files]
+
+        if self.subdirectories:
+            artifacts["subdirs"] = [d.name for d in self.subdirectories]
+            artifacts["subdir_paths"] = [d.path for d in self.subdirectories]
+
+        return artifacts
+
 
 class ListDirectoryObservation(Observation):
     """Response from listing directory contents."""
@@ -107,9 +136,29 @@ class ListDirectoryObservation(Observation):
 
     str_template: ClassVar[str] = "{directory_info}"
 
-    def render(self) -> str:
-        """Render directory listing."""
-        return self.directory_info.render()
+    def render(self, tool_call_id: str) -> ToolMessage:
+        """Render directory listing with artifacts for UI."""
+        if self.status == "error":
+            error_artifacts: ListDirectoryArtifacts = {
+                "dirpath": self.directory_info.path,
+                "name": self.directory_info.name,
+                "error": self.error,
+            }
+            return ToolMessage(
+                content=f"[ERROR LISTING DIRECTORY]: {self.directory_info.path}: {self.error}",
+                status=self.status,
+                name="list_directory",
+                artifact=error_artifacts,
+                tool_call_id=tool_call_id,
+            )
+
+        return ToolMessage(
+            content=self.directory_info.render_as_string(),
+            status=self.status,
+            name="list_directory",
+            artifact=self.directory_info.to_artifacts(),
+            tool_call_id=tool_call_id,
+        )
 
 
 def list_directory(codebase: Codebase, path: str = "./", depth: int = 2) -> ListDirectoryObservation:
@@ -136,7 +185,7 @@ def list_directory(codebase: Codebase, path: str = "./", depth: int = 2) -> List
             ),
         )
 
-    def get_directory_info(dir_obj: Directory, current_depth: int) -> DirectoryInfo:
+    def get_directory_info(dir_obj: Directory, current_depth: int, max_depth: int) -> DirectoryInfo:
         """Helper function to get directory info recursively."""
         # Get direct files (always include files unless at max depth)
         all_files = []
@@ -151,7 +200,7 @@ def list_directory(codebase: Codebase, path: str = "./", depth: int = 2) -> List
                 if current_depth > 1 or current_depth == -1:
                     # For deeper traversal, get full directory info
                     new_depth = current_depth - 1 if current_depth > 1 else -1
-                    subdirs.append(get_directory_info(subdir, new_depth))
+                    subdirs.append(get_directory_info(subdir, new_depth, max_depth))
                 else:
                     # At max depth, return a leaf node
                     subdirs.append(
@@ -161,6 +210,8 @@ def list_directory(codebase: Codebase, path: str = "./", depth: int = 2) -> List
                             path=subdir.dirpath,
                             files=None,  # Don't include files at max depth
                             is_leaf=True,
+                            depth=current_depth,
+                            max_depth=max_depth,
                         )
                     )
 
@@ -170,9 +221,11 @@ def list_directory(codebase: Codebase, path: str = "./", depth: int = 2) -> List
             path=dir_obj.dirpath,
             files=sorted(all_files),
             subdirectories=subdirs,
+            depth=current_depth,
+            max_depth=max_depth,
         )
 
-    dir_info = get_directory_info(directory, depth)
+    dir_info = get_directory_info(directory, depth, depth)
     return ListDirectoryObservation(
         status="success",
         directory_info=dir_info,

--- a/src/codegen/extensions/tools/observation.py
+++ b/src/codegen/extensions/tools/observation.py
@@ -3,6 +3,7 @@
 import json
 from typing import Any, ClassVar, Optional
 
+from langchain_core.messages import ToolMessage
 from pydantic import BaseModel, Field
 
 
@@ -37,13 +38,47 @@ class Observation(BaseModel):
         """Get string representation of the observation."""
         if self.status == "error":
             return f"Error: {self.error}"
-        details = self._get_details()
-        return self.render()
+        return self.render_as_string()
 
     def __repr__(self) -> str:
         """Get detailed string representation of the observation."""
         return f"{self.__class__.__name__}({self.model_dump_json()})"
 
-    def render(self) -> str:
-        """Render the observation as a string."""
+    def render_as_string(self) -> str:
+        """Render the observation as a string.
+
+        This is used for string representation and as the content field
+        in the ToolMessage. Subclasses can override this to customize
+        their string output format.
+        """
         return json.dumps(self.model_dump(), indent=2)
+
+    def render(self, tool_call_id: Optional[str] = None) -> ToolMessage | str:
+        """Render the observation as a ToolMessage or string.
+
+        Args:
+            tool_call_id: Optional[str] = None - If provided, return a ToolMessage.
+                If None, return a string representation.
+
+        Returns:
+            ToolMessage or str containing the observation content and metadata.
+            For error cases, includes error information in artifacts.
+        """
+        if tool_call_id is None:
+            return self.render_as_string()
+
+        # Get content first in case render_as_string has side effects
+        content = self.render_as_string()
+
+        if self.status == "error":
+            return ToolMessage(
+                content=content,
+                status=self.status,
+                tool_call_id=tool_call_id,
+            )
+
+        return ToolMessage(
+            content=content,
+            status=self.status,
+            tool_call_id=tool_call_id,
+        )

--- a/src/codegen/extensions/tools/search.py
+++ b/src/codegen/extensions/tools/search.py
@@ -11,8 +11,11 @@ import re
 import subprocess
 from typing import ClassVar
 
+from langchain_core.messages import ToolMessage
 from pydantic import Field
 
+from codegen.extensions.tools.tool_output_types import SearchArtifacts
+from codegen.extensions.tools.tool_output_types import SearchMatch as SearchMatchDict
 from codegen.sdk.core.codebase import Codebase
 
 from .observation import Observation
@@ -34,9 +37,17 @@ class SearchMatch(Observation):
     )
     str_template: ClassVar[str] = "Line {line_number}: {match}"
 
-    def render(self) -> str:
+    def render_as_string(self) -> str:
         """Render match in a VSCode-like format."""
         return f"{self.line_number:>4}:  {self.line}"
+
+    def to_dict(self) -> SearchMatchDict:
+        """Convert to SearchMatch TypedDict format."""
+        return {
+            "line_number": self.line_number,
+            "line": self.line,
+            "match": self.match,
+        }
 
 
 class SearchFileResult(Observation):
@@ -51,13 +62,13 @@ class SearchFileResult(Observation):
 
     str_template: ClassVar[str] = "{filepath}: {match_count} matches"
 
-    def render(self) -> str:
+    def render_as_string(self) -> str:
         """Render file results in a VSCode-like format."""
         lines = [
             f"📄 {self.filepath}",
         ]
         for match in self.matches:
-            lines.append(match.render())
+            lines.append(match.render_as_string())
         return "\n".join(lines)
 
     def _get_details(self) -> dict[str, str | int]:
@@ -89,11 +100,47 @@ class SearchObservation(Observation):
 
     str_template: ClassVar[str] = "Found {total_files} files with matches for '{query}' (page {page}/{total_pages})"
 
-    def render(self) -> str:
-        """Render search results in a VSCode-like format."""
-        if self.status == "error":
-            return f"[SEARCH ERROR]: {self.error}"
+    def render(self, tool_call_id: str) -> ToolMessage:
+        """Render search results in a VSCode-like format.
 
+        Args:
+            tool_call_id: ID of the tool call that triggered this search
+
+        Returns:
+            ToolMessage containing search results or error
+        """
+        # Prepare artifacts dictionary with default values
+        artifacts: SearchArtifacts = {
+            "query": self.query,
+            "error": self.error if self.status == "error" else None,
+            "matches": [],  # List[SearchMatchDict] - match data as TypedDict
+            "file_paths": [],  # List[str] - file paths with matches
+            "page": self.page,
+            "total_pages": self.total_pages if self.status == "success" else 0,
+            "total_files": self.total_files if self.status == "success" else 0,
+            "files_per_page": self.files_per_page,
+        }
+
+        # Handle error case early
+        if self.status == "error":
+            return ToolMessage(
+                content=f"[SEARCH ERROR]: {self.error}",
+                status=self.status,
+                name="search",
+                tool_call_id=tool_call_id,
+                artifact=artifacts,
+            )
+
+        # Build matches and file paths for success case
+        for result in self.results:
+            artifacts["file_paths"].append(result.filepath)
+            for match in result.matches:
+                # Convert match to SearchMatchDict format
+                match_dict = match.to_dict()
+                match_dict["filepath"] = result.filepath
+                artifacts["matches"].append(match_dict)
+
+        # Build content lines
         lines = [
             f"[SEARCH RESULTS]: {self.query}",
             f"Found {self.total_files} files with matches (showing page {self.page} of {self.total_pages})",
@@ -102,16 +149,23 @@ class SearchObservation(Observation):
 
         if not self.results:
             lines.append("No matches found")
-            return "\n".join(lines)
+        else:
+            # Add results with blank lines between files
+            for result in self.results:
+                lines.append(result.render_as_string())
+                lines.append("")  # Add blank line between files
 
-        for result in self.results:
-            lines.append(result.render())
-            lines.append("")  # Add blank line between files
+            # Add pagination info if there are multiple pages
+            if self.total_pages > 1:
+                lines.append(f"Page {self.page}/{self.total_pages} (use page parameter to see more results)")
 
-        if self.total_pages > 1:
-            lines.append(f"Page {self.page}/{self.total_pages} (use page parameter to see more results)")
-
-        return "\n".join(lines)
+        return ToolMessage(
+            content="\n".join(lines),
+            status=self.status,
+            name="search",
+            tool_call_id=tool_call_id,
+            artifact=artifacts,
+        )
 
 
 def _search_with_ripgrep(

--- a/src/codegen/extensions/tools/semantic_edit.py
+++ b/src/codegen/extensions/tools/semantic_edit.py
@@ -2,8 +2,9 @@
 
 import difflib
 import re
-from typing import ClassVar, Optional
+from typing import TYPE_CHECKING, ClassVar, Optional
 
+from langchain_core.messages import ToolMessage
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import ChatPromptTemplate
 from pydantic import Field
@@ -15,6 +16,9 @@ from .observation import Observation
 from .semantic_edit_prompts import _HUMAN_PROMPT_DRAFT_EDITOR, COMMANDER_SYSTEM_PROMPT
 from .view_file import add_line_numbers
 
+if TYPE_CHECKING:
+    from .tool_output_types import SemanticEditArtifacts
+
 
 class SemanticEditObservation(Observation):
     """Response from making semantic edits to a file."""
@@ -24,18 +28,54 @@ class SemanticEditObservation(Observation):
     )
     diff: Optional[str] = Field(
         default=None,
-        description="Unified diff showing the changes made",
+        description="Unified diff of changes made to the file",
     )
     new_content: Optional[str] = Field(
         default=None,
-        description="New content with line numbers",
+        description="New content of the file with line numbers after edits",
     )
     line_count: Optional[int] = Field(
         default=None,
-        description="Total number of lines in file",
+        description="Total number of lines in the edited file",
     )
 
     str_template: ClassVar[str] = "Edited file {filepath}"
+
+    def render(self, tool_call_id: str) -> ToolMessage:
+        """Render the observation as a ToolMessage.
+
+        Args:
+            tool_call_id: ID of the tool call that triggered this edit
+
+        Returns:
+            ToolMessage containing edit results or error
+        """
+        # Prepare artifacts dictionary with default values
+        artifacts: SemanticEditArtifacts = {
+            "filepath": self.filepath,
+            "diff": self.diff,
+            "new_content": self.new_content,
+            "line_count": self.line_count,
+            "error": self.error if self.status == "error" else None,
+        }
+
+        # Handle error case early
+        if self.status == "error":
+            return ToolMessage(
+                content=f"[EDIT ERROR]: {self.error}",
+                status=self.status,
+                name="semantic_edit",
+                tool_call_id=tool_call_id,
+                artifact=artifacts,
+            )
+
+        return ToolMessage(
+            content=self.render_as_string(),
+            status=self.status,
+            name="semantic_edit",
+            tool_call_id=tool_call_id,
+            artifact=artifacts,
+        )
 
 
 def generate_diff(original: str, modified: str) -> str:

--- a/src/codegen/extensions/tools/tool_output_types.py
+++ b/src/codegen/extensions/tools/tool_output_types.py
@@ -1,0 +1,105 @@
+"""Type definitions for tool outputs."""
+
+from typing import Optional, TypedDict
+
+
+class EditFileArtifacts(TypedDict, total=False):
+    """Artifacts for edit file operations.
+
+    All fields are optional to support both success and error cases.
+    """
+
+    filepath: str  # Path to the edited file
+    diff: Optional[str]  # Diff of changes made to the file
+    error: Optional[str]  # Error message (only present on error)
+
+
+class ViewFileArtifacts(TypedDict, total=False):
+    """Artifacts for view file operations.
+
+    All fields are optional to support both success and error cases.
+    Includes metadata useful for UI logging and pagination.
+    """
+
+    filepath: str  # Path to the viewed file
+    start_line: Optional[int]  # Starting line number viewed
+    end_line: Optional[int]  # Ending line number viewed
+    content: Optional[str]  # Content of the file
+    total_lines: Optional[int]  # Total number of lines in file
+    has_more: Optional[bool]  # Whether there are more lines to view
+    max_lines_per_page: Optional[int]  # Maximum lines that can be viewed at once
+    file_size: Optional[int]  # Size of file in bytes
+    error: Optional[str]  # Error message (only present on error)
+
+
+class ListDirectoryArtifacts(TypedDict, total=False):
+    """Artifacts for directory listing operations.
+
+    All fields are optional to support both success and error cases.
+    Includes metadata useful for UI tree view and navigation.
+    """
+
+    dirpath: str  # Full path to the directory
+    name: str  # Name of the directory
+    files: Optional[list[str]]  # List of files in this directory
+    file_paths: Optional[list[str]]  # Full paths to files in this directory
+    subdirs: Optional[list[str]]  # List of subdirectory names
+    subdir_paths: Optional[list[str]]  # Full paths to subdirectories
+    is_leaf: Optional[bool]  # Whether this is a leaf node (at max depth)
+    depth: Optional[int]  # Current depth in the tree
+    max_depth: Optional[int]  # Maximum depth allowed
+    error: Optional[str]  # Error message (only present on error)
+
+
+class SearchMatch(TypedDict, total=False):
+    """Information about a single search match."""
+
+    filepath: str  # Path to the file containing the match
+    line_number: int  # 1-based line number of the match
+    line: str  # The full line containing the match
+    match: str  # The specific text that matched
+
+
+class SearchArtifacts(TypedDict, total=False):
+    """Artifacts for search operations.
+
+    All fields are optional to support both success and error cases.
+    Includes metadata useful for UI search results and navigation.
+    """
+
+    query: str  # Search query that was used
+    page: int  # Current page number (1-based)
+    total_pages: int  # Total number of pages available
+    total_files: int  # Total number of files with matches
+    files_per_page: int  # Number of files shown per page
+    matches: list[SearchMatch]  # List of matches with file paths and line numbers
+    file_paths: list[str]  # List of files containing matches
+    error: Optional[str]  # Error message (only present on error)
+
+
+class SemanticEditArtifacts(TypedDict, total=False):
+    """Artifacts for semantic edit operations.
+
+    All fields are optional to support both success and error cases.
+    Includes metadata useful for UI diff view and file content.
+    """
+
+    filepath: str  # Path to the edited file
+    diff: Optional[str]  # Unified diff of changes made to the file
+    new_content: Optional[str]  # New content of the file after edits
+    line_count: Optional[int]  # Total number of lines in the edited file
+    error: Optional[str]  # Error message (only present on error)
+
+
+class RelaceEditArtifacts(TypedDict, total=False):
+    """Artifacts for relace edit operations.
+
+    All fields are optional to support both success and error cases.
+    Includes metadata useful for UI diff view and file content.
+    """
+
+    filepath: str  # Path to the edited file
+    diff: Optional[str]  # Unified diff of changes made to the file
+    new_content: Optional[str]  # New content of the file after edits
+    line_count: Optional[int]  # Total number of lines in the edited file
+    error: Optional[str]  # Error message (only present on error)

--- a/tests/unit/codegen/extensions/test_tools.py
+++ b/tests/unit/codegen/extensions/test_tools.py
@@ -225,14 +225,14 @@ def test_list_directory(codebase):
     core_dir = next(d for d in src_dir.subdirectories if d.name == "core")
 
     # Verify rendered output has proper tree structure
-    rendered = result.render()
+    rendered = result.render(tool_call_id="test")
     print(rendered)
     expected_tree = """
 └── src/
     ├── main.py
     ├── utils.py
     └── core/"""
-    assert expected_tree in rendered.strip()
+    assert expected_tree in rendered.content.strip()
 
 
 def test_edit_file(codebase):


### PR DESCRIPTION
Reverts codegen-sh/codegen#892

---------

# Motivation

<!-- Why is this change necessary? -->

# Content

<!-- Please include a summary of the change -->

# Testing

<!-- How was the change tested? -->

# Please check the following before marking your PR as ready for review

- [ ] I have added tests for my changes
- [ ] I have updated the documentation or added new documentation as needed

## Summary by Sourcery

Revert a previous reversion and add schema definitions for tool outputs, introducing structured artifacts for various tool operations

New Features:
- Added new tool_output_types.py with TypedDict definitions for structured tool artifacts
- Introduced artifact generation for search, view file, list directory, edit file, and semantic edit operations

Enhancements:
- Updated tool rendering methods to support ToolMessage with artifacts
- Modified observation classes to generate structured output artifacts
- Improved error handling and metadata generation for tool operations

Chores:
- Refactored tool rendering methods across multiple tool extension files
- Updated type hints and imports to support new artifact generation